### PR TITLE
Device Registration/Initialization

### DIFF
--- a/rtrd.c
+++ b/rtrd.c
@@ -4,6 +4,7 @@
 #include <linux/etherdevice.h>
 #include <linux/gfp_types.h>
 #include <linux/skbuff.h>
+#include <linux/skbuff.h>
 
 MODULE_LICENSE("GPL-2.0");
 
@@ -70,10 +71,26 @@ static netdev_tx_t rtrd_start_xmit(struct sk_buff *skb, struct net_device *dev)
 	return NETDEV_TX_OK;
 }
 
+static void rtrd_get_stats64(struct net_device *dev,
+			     struct rtnl_link_stats64 *stats)
+{
+	struct rtrd_priv *priv = netdev_priv(dev);
+
+	stats->rx_packets = priv->stats.rx_packets;
+	stats->tx_packets = priv->stats.tx_packets;
+	stats->rx_bytes = priv->stats.rx_bytes;
+	stats->tx_bytes = priv->stats.tx_bytes;
+	stats->rx_errors = priv->stats.rx_errors;
+	stats->tx_errors = priv->stats.tx_errors;
+	stats->rx_dropped = priv->stats.rx_dropped;
+	stats->tx_dropped = priv->stats.tx_dropped;
+}
+
 static const struct net_device_ops rtrd_netdev_ops = {
 	.ndo_open = rtrd_open,
 	.ndo_stop = rtrd_stop,
 	.ndo_start_xmit = rtrd_start_xmit,
+	.ndo_get_stats64 = rtrd_get_stats64,
 };
 
 static void rtrd_probe(struct net_device *dev)

--- a/rtrd.c
+++ b/rtrd.c
@@ -12,11 +12,48 @@ MODULE_LICENSE("GPL-2.0");
 
 static struct net_device *rtrd_dev;
 
+static const struct net_device_ops rtrd_netdev_ops = {};
+
+struct rtrd_priv {
+	struct net_device_stats stats;
+	spinlock_t lock;
+};
+
+static void rtrd_probe(struct net_device *dev)
+{
+	struct rtrd_priv *priv;
+
+	ether_setup(dev);
+
+	dev->netdev_ops = &rtrd_netdev_ops;
+
+	/*
+	 * IFF_NOARP: We're not using ARP
+	 * IFF_POINTOPOINT: This is a tunnel, not broadcast medium
+	 */
+	dev->flags |= IFF_NOARP | IFF_POINTOPOINT;
+	dev->flags &= ~IFF_BROADCAST; /* Not a broadcast device */
+
+	/* We handle our own checksums */
+	dev->features |= NETIF_F_HW_CSUM | NETIF_F_HIGHDMA;
+
+	/* Disable header caching - we're not a real Ethernet */
+	dev->header_ops = NULL;
+
+	/* WireGuard uses 1420 to fit in Ethernet */
+	dev->mtu = 1420;
+
+	priv = netdev_priv(dev);
+	memset(priv, 0, sizeof(struct rtrd_priv));
+	spin_lock_init(&priv->lock);
+}
+
 static int __init rtrd_init(void)
 {
 	int ret;
 
-	rtrd_dev = alloc_netdev(0, "rtrd%d", NET_NAME_UNKNOWN, NULL);
+	rtrd_dev = alloc_netdev(sizeof(struct rtrd_priv), "rtrd%d",
+				NET_NAME_UNKNOWN, rtrd_probe);
 	if (!rtrd_dev) {
 		RTRD_DBG("alloc_netdev failed");
 		return -ENOMEM; /* FIXME: This is just assumption */

--- a/rtrd.c
+++ b/rtrd.c
@@ -1,6 +1,7 @@
 #include <linux/init.h>
 #include <linux/module.h>
 #include <linux/netdevice.h>
+#include <linux/etherdevice.h>
 
 MODULE_LICENSE("GPL-2.0");
 
@@ -12,11 +13,27 @@ MODULE_LICENSE("GPL-2.0");
 
 static struct net_device *rtrd_dev;
 
-static const struct net_device_ops rtrd_netdev_ops = {};
-
 struct rtrd_priv {
 	struct net_device_stats stats;
 	spinlock_t lock;
+};
+
+static int rtrd_open(struct net_device *dev)
+{
+	eth_hw_addr_set(dev, "\0RTRD"); /* Set fake MAC address */
+	netif_start_queue(dev);
+	return 0;
+}
+
+static int rtrd_stop(struct net_device *dev)
+{
+	netif_stop_queue(dev);
+	return 0;
+}
+
+static const struct net_device_ops rtrd_netdev_ops = {
+	.ndo_open = rtrd_open,
+	.ndo_stop = rtrd_stop,
 };
 
 static void rtrd_probe(struct net_device *dev)


### PR DESCRIPTION
This PR adds the net device registration and initialization. After loading the module, use `ip link set rtrd0 up` and `ip addr add 10.0.0.1/24 dev rtrd0` to set the device in the "UP" state and assign an IP address. Pinging the address seems to crash my VM.